### PR TITLE
ユーザー編集の際のパスワード入力バリデーション修正 issues/#65

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :name,  presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
-  validates :password, presence: true, length: { maximum: 50 }
+  validates :password, presence: true, on: :create, length: { maximum: 50 }
   before_validation { email.downcase! }
 
   def self.guest


### PR DESCRIPTION
#65 

- ユーザー編集の際にパスワードを入力せずとも編集できるはずが、「パスワードを入力してください」と表示されるため修正